### PR TITLE
Define cryptfs_hw path

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -113,6 +113,7 @@ LOCAL_CFLAGS := $(vold_cflags)
 LOCAL_CONLYFLAGS := $(vold_conlyflags)
 
 ifeq ($(TARGET_HW_DISK_ENCRYPTION),true)
+TARGET_CRYPTFS_HW_PATH ?= device/qcom/common/cryptfs_hw
 LOCAL_C_INCLUDES += $(TARGET_CRYPTFS_HW_PATH)
 common_shared_libraries += libcryptfs_hw
 LOCAL_CFLAGS += -DCONFIG_HW_DISK_ENCRYPTION


### PR DESCRIPTION
without this there is an good probability to get stucked with some missing include errors

Change-Id: I0d2659c88b54f851cdf7a37a8566eab0bfb51e54